### PR TITLE
cleaning up files used by browserify on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "logmimosa": "0.5.0",
     "browserify": "2.29.0",
     "browserify-shim": "2.0.8",
-    "lodash": "1.3.1"
+    "lodash": "1.3.1",
+    "wrench": "1.5.1"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This should handle cleaning up the aftermath.  Left some commented loggers in.  Was undecided if any of that stuff should be written as infos or successes, or just left out entirely.  Wasn't able to see what mimosa-require does because it seems some of the tracking stuff is breaking mimosa-require's optimized builds for some odd reason.
