### PR TITLE
When tidying up excluding bundled files from node_modules.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -132,7 +132,8 @@ _whenDone = (mimosaConfig, bundledFiles, next) ->
 
 _cleanUpBuild = (mimosaConfig, bundledFiles) ->
   bundledFiles = _.uniq bundledFiles
-  for f in bundledFiles
+  filesToClean = bundledFiles.filter (f) -> !f.match /\/node_modules\//
+  filesToClean.forEach (f) ->
     if fs.existsSync f
       fs.unlinkSync f
 


### PR DESCRIPTION
Before doing this if browserify was used to require any node modules
from the node_modules directory they were being deleted in the post
bundle clean up.
