### PR TITLE
when cleaning up, consider windows paths

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -137,7 +137,7 @@ _whenDone = (mimosaConfig, bundledFiles, next) ->
 
 _cleanUpBuild = (mimosaConfig, bundledFiles) ->
   bundledFiles = _.uniq bundledFiles
-  filesToClean = bundledFiles.filter (f) -> !f.match /\/node_modules\//
+  filesToClean = bundledFiles.filter (f) -> !f.match /[\\\/]node_modules[\\\/]/
   filesToClean.forEach (f) ->
     if fs.existsSync f
       fs.unlinkSync f


### PR DESCRIPTION
prevent require'd node_modules from getting deleted after every build on windows.
