### PR TITLE
Split code into bundles with browserify.external

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mimosa-browserify",
-  "version": "0.2.0",
+  "name": "mimosa-browserify-averbin",
+  "version": "0.2.1",
   "homepage": "https://github.com/JonET",
   "author": "Jon Taylor",
   "description": "CommonJS support for Mimosa via Browserify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mimosa-browserify-averbin",
-  "version": "0.2.1",
+  "name": "mimosa-browserify",
+  "version": "0.2.0",
   "homepage": "https://github.com/JonET",
   "author": "Jon Taylor",
   "description": "CommonJS support for Mimosa via Browserify",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -61,7 +61,12 @@ _browserify = (mimosaConfig, options, next) ->
     _fixShims b, mimosaConfig
 
     for entry in bundleConfig.entries
-      b.add path.join root, entry
+      b.add path.join root, entry      
+
+    if bundleConfig.external?
+      for external in bundleConfig.external
+        entry = path.join root, external
+        b.external entry
 
     bundleCallback = _bundleCallback bundleConfig, bundlePath, whenDone
     bundle         = b.bundle browerifyOptions, bundleCallback


### PR DESCRIPTION
With this pull request you can split your app in more that one bundle and mix and match them as you find suitable. For example you can split your code into two bundles and load them in parallel to speed up js loading. Or you can split your code into "shared code", "code specific to page 1", "code specific to page 2", etc. bundles and then load it only required parts on each page.

Sample mimosa-config
libs = ["/vendor/js/jquery/jquery", "/vendor/js/bootstrap/bootstrap", ....]
browserify:
    bundles:
      [{
          entries: libs
          outputFile: 'lib-bundle.js'
      },{
          entries: ['js/app.js']
          outputFile: 'app-bundle.js'
          external: libs
      }]
